### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function Xray() {
           if (!isUrl(url)) {
             debug('%j is not a url, finishing up', url);
             stream(obj, true);
-            fn(null, pages);
+            return fn(null, pages);
           }
 
           stream(obj);


### PR DESCRIPTION
Fix to .limit(n): if the next page is not a url (e.g. the link is broken or we reached the last page), the method should return fn(null, pages), and not call fn(null, pages) and continue to the next page.

Right now, x-ray crashes if the we choose n > number of pages in limit(n), whereas it should just return the fn(null, pages) once it reaches the end.