### PR TITLE
fixed the double call of the callback function

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function Xray() {
           if (!isUrl(url)) {
             debug('%j is not a url, finishing up', url);
             stream(obj, true);
-            fn(null, pages);
+            return fn(null, pages);
           }
 
           stream(obj);

--- a/test/index.js
+++ b/test/index.js
@@ -247,6 +247,21 @@ describe('Xray()', function() {
 
   });
 
+  it('should not call function twice when reaching the last page', function(done){
+    this.timeout(10000);
+    setTimeout(done, 9000);
+    var timesCalled = 0;
+    var x = Xray();
+
+    x('https://github.com/lapwinglabs/x-ray/watchers', '.follow-list-item', [{
+      fullName: '.vcard-username'
+    }]).paginate('.next_page@href').limit(10)
+    (function(err, arr) {
+      timesCalled++;
+      assert.equal(1, timesCalled, 'callback was called more than once');
+    });
+  });
+
   describe('.format()', function() {
     it('should support adding formatters', function() {
       // TODO


### PR DESCRIPTION
When reaching the last page the callback function is called twice.
This fixes https://github.com/lapwinglabs/x-ray/pull/53

Added a test but it’s a bit messy because it’s a negative test and I am
not a javascript dev so I hope someone can refactor it in a more
elegant way.