### PR TITLE
Issue when one of the selector is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,15 +172,15 @@ function Xray() {
       walk(selector, function(v, k, next) {
         if ('string' == typeof v) {
           var value = resolve($, root(scope), v);
-          next(null, value);
+          return next(null, value);
         } else if ('function' == typeof v) {
           v($, function(err, obj) {
             if (err) return next(err);
-            next(null, obj);
+            return next(null, obj);
           });
         } else if (isArray(v)) {
           if ('string' == typeof v[0]) {
-            next(null, resolve($, root(scope), v));
+            return next(null, resolve($, root(scope), v));
           } else if ('object' == typeof v[0]) {
             var $scope = $.find ? $.find(scope) : $(scope);
             var pending = $scope.length;
@@ -197,6 +197,7 @@ function Xray() {
             });
           }
         }
+        return next();
       }, function(err, obj) {
         if (err) return fn(err);
         fn(null, obj, $);

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function Xray() {
           if (!isUrl(url)) {
             debug('%j is not a url, finishing up', url);
             stream(obj, true);
-            fn(null, pages);
+            return fn(null, pages);
           }
 
           stream(obj);


### PR DESCRIPTION
Fixed an issue where the fn function would not be called if one of the selector was null