### PR TITLE
Add halt callback for early exit of pagination

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,14 +126,25 @@ function Xray() {
             pages.push(obj);
           }
 
+          if (paginate.hasOwnProperty('halt') && paginate.halt(pages)) {
+            debug('pagination halt condition met, ending');
+            stream(obj, true);
+            return fn(null, pages);
+          }
+
           if (limit <= 0) {
             debug('reached limit, ending');
             stream(obj, true);
             return fn(null, pages);
           }
 
-          var url = resolve($, false, paginate);
-          debug('paginate(%j) => %j', paginate, url);
+          var paginationSelector = paginate.hasOwnProperty('selector')
+            ? paginate.selector
+            : paginate;
+
+          var url = resolve($, false, paginationSelector);
+
+          debug('paginate(%j) => %j', paginationSelector, url);
 
           if (!isUrl(url)) {
             debug('%j is not a url, finishing up', url);

--- a/test/index.js
+++ b/test/index.js
@@ -247,6 +247,49 @@ describe('Xray()', function() {
 
   });
 
+  // TODO: this could also be tested better, need a static site
+  // with pages
+  it('should paginate with paginate.selector property set', function(done) {
+    this.timeout(10000)
+    var x = Xray();
+
+    x('li.group', [{
+      title: '.dribbble-img strong',
+      image: '.dribbble-img [data-src]@data-src',
+    }]).paginate({selector: '.next_page@href'}).limit(3)
+    ('https://dribbble.com', function(err, arr) {
+      if (err) return done(err);
+      assert(arr.length, 'array should have a length');
+      arr.forEach(function(item) {
+        assert(item.title.length);
+        assert.equal(true, isUrl(item.image));
+      })
+      done();
+    });
+
+  });
+
+  // TODO: this could be tested better, need a static site
+  // with pages as this will fail if dribble ever presents more than 12
+  // images per page
+  it('should halt pagination when pagination.halt condition met', function(done){
+    this.timeout(10000)
+    var x = Xray();
+
+    x('li.group', [{
+      title: '.dribbble-img strong',
+      image: '.dribbble-img [data-src]@data-src',
+    }]).paginate({selector: '.next_page@href', halt: function (data){
+      return data.length == 12 ? true : false;
+    }}).limit(3)
+    ('https://dribbble.com', function(err, arr) {
+      if (err) return done(err);
+      assert.equal(arr.length, 12);
+      done();
+    });
+
+  });
+
   it('should not call function twice when reaching the last page', function(done){
     this.timeout(10000);
     setTimeout(done, 9000);


### PR DESCRIPTION
In my use case I needed to stop pagination once a condition was met.
Specifically once an already scraped data point was reached.

This commit adds the option of an object for pagination with
selector (string) and halt (callback function) properties.

The halt callback will not stop pagination until it returns true. Once it returns true it returns the pages data.