### PR TITLE
Emit error on correct stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ function Xray() {
       }
 
       node(function(err) {
-        if (err) state.stream.emit('error', err);
+        if (err) ret.emit('error', err);
       })
 
       return ret;


### PR DESCRIPTION
This change fixes one of the issues from #98. `state.stream` can be the wrong stream to emit an error to if no path is passed. On the other hand, `ret` will always be the right stream to emit to. 

This makes it possible to listen for 'error' events although an error is still squelched if it's not listened for.