### PR TITLE
Fix potential issue when selector is a function following comments on…

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ function Xray() {
           var value = resolve($, root(scope), v);
           return next(null, value);
         } else if ('function' == typeof v) {
-          v($, function(err, obj) {
+          return v($, function(err, obj) {
             if (err) return next(err);
             return next(null, obj);
           });


### PR DESCRIPTION
… commit e7318d591908d04b439c1ff7e93ff9c4b63a89af

When the selector v is a function, the function next() will most likely be called twice: once because there is no return before calling the function v, and once again when the callback for v is called.

As @bdentino notes, this could cause problems down the line because the next() is called too many times.