### PR TITLE
Change to documentation of support for raw HTML

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,7 +79,7 @@ Instead of a url, you can also supply raw HTML and all the same semantics apply.
 
 ```js
 var html = "<body><h2>Pear</h2></body>";
-x(html, 'body', 'h2', function(err, header) {
+x(html, 'body', 'h2')(function(err, header) {
   header // => Pear
 })
 ```


### PR DESCRIPTION
The documentation for support of raw HTML states "...all the same sematics apply" but the example provided uses different semantics. Instead of `x()` being a function that returns a function that takes a callback, `x()` is a function that takes a callback. I believe this is is not correct.