### PR TITLE
doc - API usage correction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,7 @@ var app = require('express')();
 var x = require('x-ray')();
 
 app.get('/', function(req, res) {
-  res.send(x('http://google.com', 'title').steam());
+  res.send(x('http://google.com', 'title').stream());
 })
 ```
 


### PR DESCRIPTION
Simple Readme.md tweak
The API usage example for xray.stream() was noted as `xray.steam()`