### PR TITLE
fix error when html is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,6 +192,7 @@ function Request (crawler) {
 }
 
 function load (html, url) {
+    html = html || '';
   var $ = html.html ? html : cheerio.load(html)
   if (url) $ = absolutes(url, $)
   return $


### PR DESCRIPTION
### Description

html to empty before cheerio.load.