### PR TITLE
Absolutizing fails when encountering malformed URLs

### DIFF
--- a/lib/absolutes.js
+++ b/lib/absolutes.js
@@ -26,6 +26,24 @@ var selector = [
   'iframe[src]'
 ].join(',')
 
+
+/**
+ * Checks if a given string is a valid URL
+ *
+ * @param {String} src
+ * @return {Boolean}
+ */
+
+function isValidUrl (src) {
+  try {
+    url.parse(src);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+
 /**
  * Change all the URLs into absolute urls
  *
@@ -69,7 +87,7 @@ function absolute (path, $) {
 
     if (~src.indexOf('://')) {
       return
-    } else {
+    } else if (isValidUrl(src)) {
       var current
       if (href && src.indexOf('/') !== 0) {
         current = url.resolve(remote, href)

--- a/lib/absolutes.js
+++ b/lib/absolutes.js
@@ -26,7 +26,6 @@ var selector = [
   'iframe[src]'
 ].join(',')
 
-
 /**
  * Checks if a given string is a valid URL
  *
@@ -42,7 +41,6 @@ function isValidUrl (src) {
     return false
   }
 }
-
 
 /**
  * Change all the URLs into absolute urls

--- a/lib/absolutes.js
+++ b/lib/absolutes.js
@@ -36,10 +36,10 @@ var selector = [
 
 function isValidUrl (src) {
   try {
-    url.parse(src);
-    return true;
+    url.parse(src)
+    return true
   } catch (e) {
-    return false;
+    return false
   }
 }
 

--- a/test/absolutes_spec.js
+++ b/test/absolutes_spec.js
@@ -24,7 +24,12 @@ describe('absolute URLs', function () {
   it('should convert relative URL', function () {
     var $el = cheerio.load('<a href="bar.html"></a>')
     assert.equal('<a href="http://example.com/bar.html"></a>', absolute(path, $el).html())
-  })
+  });
+
+  it('should not throw when encountering invalid URLs', function () {
+    var $el = cheerio.load('<html><body><ul><li><a href="mailto:%CAbroken@link.com">Broken link</a></li></ul></body></html>');
+    absolute(path, $el);
+  });
 })
 
 describe('absolute URLs with <base> tag', function () {

--- a/test/absolutes_spec.js
+++ b/test/absolutes_spec.js
@@ -24,12 +24,12 @@ describe('absolute URLs', function () {
   it('should convert relative URL', function () {
     var $el = cheerio.load('<a href="bar.html"></a>')
     assert.equal('<a href="http://example.com/bar.html"></a>', absolute(path, $el).html())
-  });
+  })
 
   it('should not throw when encountering invalid URLs', function () {
-    var $el = cheerio.load('<html><body><ul><li><a href="mailto:%CAbroken@link.com">Broken link</a></li></ul></body></html>');
-    absolute(path, $el);
-  });
+    var $el = cheerio.load('<html><body><ul><li><a href="mailto:%CAbroken@link.com">Broken link</a></li></ul></body></html>')
+    absolute(path, $el)
+  })
 })
 
 describe('absolute URLs with <base> tag', function () {


### PR DESCRIPTION
### Description
Hello there,

I ran into an issue while using this otherwise excellent tool, that it crashed when absolutes encountered a malformed URL, an invalid mailto in my case because the `url.resolve()` function throws when it is passed an invalid URL. I added an `isValidUrl` check before the absolutes function calls the `url.resolve()` method. 

I added a test for this as well. 

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
… urls in a document.