### PR TITLE
bugfix - webpack is not treating isObject as fn

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -6,6 +6,8 @@ var isObject = require('isobject')
 var isUrl = require('is-url')
 var isArray = Array.isArray
 
+isObject = 'default' in isObject ? isObject['default'] : isObject
+
 /**
  * Get the root, if there is one.
  *


### PR DESCRIPTION
### Description

Please explain the changes you made here.
isObject package is using the default export and when x-ray is getting compiled using webpack, then the output package is not able to detect isObject as a function.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary