### PR TITLE
Update cheerio to 1.0.0-rc.2

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -116,7 +116,7 @@ function attribute ($el, attr) {
     case 'html':
       return $el.html()
     case 'text':
-      return $el.prop('innerText')
+      return $el.text()
     default:
       return $el.attr(attr)
   }

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -116,7 +116,7 @@ function attribute ($el, attr) {
     case 'html':
       return $el.html()
     case 'text':
-      return $el.text()
+      return $el.prop('innerText')
     default:
       return $el.attr(attr)
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "batch": "~0.6.0",
     "bluebird": "^3.4.7",
     "chalk": "~2.4.0",
-    "cheerio": "~0.22.0",
+    "cheerio": "1.0.0-rc.2",
     "debug": "~4.1.0",
     "enstore": "~1.0.1",
     "is-url": "~1.2.0",


### PR DESCRIPTION
### Description

`$el.text()` will extract text in style and script tag in cheerio 0.22.0, that's not my expected behavior, so I updated the dependency to 1.0.0-rc.2.
See the cheerio issue [#1018](https://github.com/cheeriojs/cheerio/pull/1018) and changelog [1.0.0-rc.2 / 2017-07-02](https://github.com/cheeriojs/cheerio/blob/0c787f656a2cd44ca36a1ab70dccc7c8d98340de/History.md).
I think this change will benefit other people too.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary